### PR TITLE
Add an Add Current Editing Scene Button

### DIFF
--- a/addons/QuickSceneRunner/QuickSceneRunner.gd
+++ b/addons/QuickSceneRunner/QuickSceneRunner.gd
@@ -37,4 +37,3 @@ func _exit_tree():
 	remove_control_from_bottom_panel(dock)
 	remove_control_from_container(CONTAINER_TOOLBAR, button)
 	dock.free()
-	button.free()

--- a/addons/QuickSceneRunner/QuickSceneRunner.tscn
+++ b/addons/QuickSceneRunner/QuickSceneRunner.tscn
@@ -3,13 +3,27 @@
 [ext_resource type="Script" path="res://addons/QuickSceneRunner/SceneRunner.gd" id="1"]
 
 [node name="QuickSceneRunner" type="VBoxContainer"]
+anchors_preset = 10
+anchor_right = 1.0
+offset_bottom = 35.0
+grow_horizontal = 2
 script = ExtResource("1")
 
-[node name="Button" type="Button" parent="."]
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
 layout_mode = 2
+
+[node name="AddSceneButton" type="Button" parent="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
 text = "Add scene"
+
+[node name="AddCurrentSceneButton" type="Button" parent="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Add current scene"
 
 [node name="Scenes" type="HFlowContainer" parent="."]
 layout_mode = 2
 
-[connection signal="pressed" from="Button" to="." method="on_add"]
+[connection signal="pressed" from="HBoxContainer/AddSceneButton" to="." method="_on_add_scene_button_pressed"]
+[connection signal="pressed" from="HBoxContainer/AddCurrentSceneButton" to="." method="_on_add_current_scene_button_pressed"]

--- a/addons/QuickSceneRunner/SceneRunner.gd
+++ b/addons/QuickSceneRunner/SceneRunner.gd
@@ -25,8 +25,6 @@ func _notification(what: int) -> void:
 	if what == NOTIFICATION_THEME_CHANGED:
 		plugin.button.icon = get_theme_icon(&"TransitionSync", &"EditorIcons")
 
-func on_add() -> void:
-	add_scene("")
 
 func add_scene(path: String):
 	var scene: Control = preload("res://addons/QuickSceneRunner/QuickScene.tscn").instantiate()
@@ -87,3 +85,12 @@ func select_button():
 		$Scenes.get_child(0).get_node(^"%Bound").button_pressed = true
 	else:
 		plugin.button.disabled = true
+
+
+func _on_add_scene_button_pressed():
+	add_scene("")
+	pass
+
+func _on_add_current_scene_button_pressed():
+	add_scene(get_tree().edited_scene_root.scene_file_path)
+	pass # Replace with function body.


### PR DESCRIPTION
Hey 😄  I don't know if it's a wanted feature but I made this for my workflow so I wanted to share it 


### Description :

Add a second button to directly add a QuickScene Runner with the path of the current editing scene

This pull request engage the following modification : 
- Rename `Button` into `AddSceneButton` on `QuickSceneRunner.tscn`
- Add an `HboxContainer` into `QuickSceneRunner.tscn` to put the two button next to each other
- Add `AddCurrentSceneButton` on `QuickSceneRunner.tscn`
- Rename signal `on_add` into `_on_add_scene_button_pressed`
- Add signal `_on_add_current_scene_button_pressed`

### Test : 

_**Tested on Godot 4.3**_

- Just activate the plugin and try to add a scene with the second button : this should add a QuickScene Runner with the Path of your editing scene already set !
- Check if the Add Scene button still work : this should add a QuickScene Runner without a path set 
